### PR TITLE
Ensure constant spline trajectory uses point copies

### DIFF
--- a/raceline_editor/raceline/processing.py
+++ b/raceline_editor/raceline/processing.py
@@ -1,4 +1,5 @@
 import numpy as np
+from dataclasses import replace
 from scipy.interpolate import CubicSpline
 from typing import List
 from .models import RecordedTrajectory, SplineTrajectory, TrajectoryPoint
@@ -45,7 +46,7 @@ def _create_constant_spline_trajectory(
 
     # num_spline_segments means num_spline_segments + 1 points
     for _ in range(num_points):
-        spline_traj.points.append(first_point_data)  # Add copies
+        spline_traj.points.append(replace(first_point_data))
     return spline_traj
 
 


### PR DESCRIPTION
## Summary
- ensure constant spline trajectories append copies of the initial point so each entry is independent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42c96e3c083209d1fa577b0368706