### PR TITLE
Add numpy import to models module

### DIFF
--- a/raceline_editor/raceline/models.py
+++ b/raceline_editor/raceline/models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List, Any, Optional
 
+import numpy as np
+
 
 @dataclass
 class TrajectoryPoint:
@@ -32,8 +34,6 @@ class RecordedTrajectory:
 
     def get_arrays(self):
         """Extract trajectory data as numpy arrays for visualization."""
-        import numpy as np
-
         if not self.points:
             return {
                 attr: np.array([])


### PR DESCRIPTION
## Summary
- add a module-level numpy import in `raceline/models.py`
- remove the redundant inner import now that numpy is imported at the top level

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42c91b78c83209ae824013d0881ab